### PR TITLE
Add file name to licensedb.Analyse output and license-detector CLI JSON output

### DIFF
--- a/licensedb/analysis.go
+++ b/licensedb/analysis.go
@@ -43,6 +43,7 @@ type Result struct {
 type Match struct {
 	License    string  `json:"license"`
 	Confidence float32 `json:"confidence"`
+	File       string  `json:"file"`
 }
 
 func process(arg string) ([]Match, error) {
@@ -71,7 +72,7 @@ func process(arg string) ([]Match, error) {
 
 	var matches []Match
 	for k, v := range ls {
-		matches = append(matches, Match{k, v.Confidence})
+		matches = append(matches, Match{k, v.Confidence, v.File})
 	}
 	sort.Slice(matches, func(i, j int) bool { return matches[i].Confidence > matches[j].Confidence })
 	return matches, nil

--- a/licensedb/api/api.go
+++ b/licensedb/api/api.go
@@ -5,4 +5,5 @@ package api
 type Match struct {
 	Files      map[string]float32
 	Confidence float32
+	File       string
 }

--- a/licensedb/internal/investigation.go
+++ b/licensedb/internal/investigation.go
@@ -77,6 +77,7 @@ func investigateCandidates(candidates map[string][]byte, f func(text []byte) map
 			match.Files[file] = sim
 			if sim > match.Confidence {
 				match.Confidence = sim
+				match.File = file
 			}
 			matches[name] = match
 		}


### PR DESCRIPTION
I think this could be pretty useful for people using CLI in their scripts.
This doesn't break existing APIs, only adds a new field.
