### PR TITLE
doc: update dead links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ func main() {
 
 ## Quality
 
-On the [dataset](dataset.zip) of ~1000 most starred repositories on GitHub as of early February 2018
-([list](dataset.projects.gz)), **99%** of the licenses are detected.
+On the [dataset](licensedb/dataset.zip) of ~1000 most starred repositories on GitHub as of early February 2018
+([list](licensedb/dataset.projects.gz)), **99%** of the licenses are detected.
 The analysis of detection failures is going in [FAILURES.md](FAILURES.md).
 
 Comparison to other projects on that dataset:


### PR DESCRIPTION
Seems to be a leftover from refactoring in https://github.com/src-d/go-license-detector/commit/68b604cdb08a3b86e4a3aa8dae54e987344f1a35#diff-bb8185fd5e184d076e8b11efe56ec96158732a34839da23a59a2718fb146425d
