### PR TITLE
Make a shallow clone when cloning a git repository

### DIFF
--- a/licensedb/filer/filer.go
+++ b/licensedb/filer/filer.go
@@ -106,7 +106,8 @@ type gitFiler struct {
 	root *object.Tree
 }
 
-// FromGitURL returns a Filer that allows accessing all the files in a Git repository given its URL.
+// FromGitURL returns a Filer that allows to access all the files in a Git repository's default branch given its URL.
+// It keeps a shallow single-branch clone of the repository in memory.
 func FromGitURL(url string) (Filer, error) {
 	repo, err := git.Clone(memory.NewStorage(), nil, &git.CloneOptions{URL: url, Depth: 1})
 	if err != nil {

--- a/licensedb/filer/filer.go
+++ b/licensedb/filer/filer.go
@@ -108,7 +108,7 @@ type gitFiler struct {
 
 // FromGitURL returns a Filer that allows accessing all the files in a Git repository given its URL.
 func FromGitURL(url string) (Filer, error) {
-	repo, err := git.Clone(memory.NewStorage(), nil, &git.CloneOptions{URL: url})
+	repo, err := git.Clone(memory.NewStorage(), nil, &git.CloneOptions{URL: url, Depth: 1})
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not clone repo from %s", url)
 	}


### PR DESCRIPTION
When cloning, set the `Depth` to one so that we don't fetch older commits unnecessarily﻿
