### PR TITLE
Added Github action to reproduce races and fixed

### DIFF
--- a/.github/workflows/race.yml
+++ b/.github/workflows/race.yml
@@ -1,0 +1,14 @@
+on: [push, pull_request]
+name: Race
+jobs:
+  race:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.14.x
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Test race
+      run: go test -v -race ./...

--- a/licensedb/internal/processors/markup.go
+++ b/licensedb/internal/processors/markup.go
@@ -2,9 +2,14 @@ package processors
 
 import (
 	"bytes"
+	"sync"
 
 	rst "github.com/hhatto/gorst"
 	"github.com/russross/blackfriday/v2"
+)
+
+var (
+	parserLock sync.Mutex
 )
 
 // Markdown converts Markdown to plain text. It tries to revert all the decorations.
@@ -17,6 +22,8 @@ func Markdown(text []byte) []byte {
 // RestructuredText converts ReStructuredText to plain text.
 // It tries to revert all the decorations.
 func RestructuredText(text []byte) []byte {
+	parserLock.Lock()
+	defer parserLock.Unlock()
 	parser := rst.NewParser(nil)
 	input := bytes.NewBuffer(text)
 	output := &bytes.Buffer{}


### PR DESCRIPTION
For #9 - reproducing data races in `licensedb.Detect()`:
added workflow for tests with `-race` flag enabled.

Fixes #9 by wrapping problematic calls with `sync.Mutex` locks (it's prose chunks parser and rst markdown processor).