### PR TITLE
Bump golangci-lint-action version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,9 +8,9 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Run GolangCI-Lint 
-      uses: golangci/golangci-lint-action@v1
+      uses: golangci/golangci-lint-action@v2
       with:
-        version: v1.27
+        version: v1.29
 
     - name: Test
       run: go test ./...


### PR DESCRIPTION
fix CI failure on lint profile similar to https://github.com/golangci/golangci-lint-action/issues/127