### PR TITLE
Preload method with benchmarks

### DIFF
--- a/licensedb/internal/investigation.go
+++ b/licensedb/internal/investigation.go
@@ -161,3 +161,8 @@ func InvestigateReadmeText(text []byte, fs filer.Filer) map[string]float32 {
 func IsLicenseDirectory(fileName string) bool {
 	return licenseDirectoryRe.MatchString(strings.ToLower(fileName))
 }
+
+// Preload license database
+func Preload() {
+	_ = globalLicenseDatabase()
+}

--- a/licensedb/licensedb.go
+++ b/licensedb/licensedb.go
@@ -54,7 +54,12 @@ func Detect(fs filer.Filer) (map[string]api.Match, error) {
 	return licenses, nil
 }
 
-// Preload database with licenses
+// Preload database with licenses - load internal database from assets into memory.
+// This method is an optimization for cases when the `Detect` method should return fast,
+// e.g. in HTTP web servers where connection timeout can occur during detect
+// `Preload` method could be called before server startup.
+// This method os optional and it's not required to be called, other APIs loads license database
+// lazily on first invocation.
 func Preload() {
 	internal.Preload()
 }

--- a/licensedb/licensedb.go
+++ b/licensedb/licensedb.go
@@ -53,3 +53,8 @@ func Detect(fs filer.Filer) (map[string]api.Match, error) {
 	}
 	return licenses, nil
 }
+
+// Preload database with licenses
+func Preload() {
+	internal.Preload()
+}

--- a/licensedb/licensedb_test.go
+++ b/licensedb/licensedb_test.go
@@ -1,0 +1,45 @@
+package licensedb
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-enry/go-license-detector/v4/licensedb/filer"
+)
+
+func BenchmarkDetect(b *testing.B) {
+	f := pwdFiler()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := Detect(f)
+		if err != nil {
+			panic(err)
+		}
+	}
+}
+
+func BenchmarkDetectWithPreload(b *testing.B) {
+	f := pwdFiler()
+	Preload()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := Detect(f)
+		if err != nil {
+			panic(err)
+		}
+	}
+}
+
+func pwdFiler() filer.Filer {
+	pwd, err := os.Getwd()
+	if err != nil {
+		panic(err)
+	}
+	root := filepath.Dir(pwd)
+	f, err := filer.FromDirectory(root)
+	if err != nil {
+		panic(err)
+	}
+	return f
+}


### PR DESCRIPTION
Fixes #13 - added preload method to initialize database without
performing any license check. Added two benchmarks to compare
the difference between calls with and without preload.