### PR TITLE
Stable result order for entries with equal confidence

### DIFF
--- a/licensedb/analysis.go
+++ b/licensedb/analysis.go
@@ -74,6 +74,11 @@ func process(arg string) ([]Match, error) {
 	for k, v := range ls {
 		matches = append(matches, Match{k, v.Confidence, v.File})
 	}
-	sort.Slice(matches, func(i, j int) bool { return matches[i].Confidence > matches[j].Confidence })
+	sort.Slice(matches, func(i, j int) bool {
+		if matches[i].Confidence == matches[j].Confidence {
+			return matches[i].License < matches[j].License
+		}
+		return matches[i].Confidence > matches[j].Confidence
+	})
 	return matches, nil
 }


### PR DESCRIPTION
In case of two result entries with equal confidence level, the order of these entries is randomized. This makes comparing two result sets non-trivial.

This PR orders the result entries by confidence first and by license name second to achieve a stable output.

Example:
The two top entries have the same confidence level and thus appear either as
```
$ ./license-detector https://github.com/gogo/protobuf | head -3
https://github.com/gogo/protobuf
        100%    BSD-2-Clause
        100%    0BSD
```
or as
```
https://github.com/gogo/protobuf
        100%    0BSD
        100%    BSD-2-Clause
```